### PR TITLE
HL2 Movement

### DIFF
--- a/code/Player/Player.Controller.Base.cs
+++ b/code/Player/Player.Controller.Base.cs
@@ -1,0 +1,377 @@
+
+using Sandbox;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TTT;
+
+
+// Ported directly from Sandbox (obsolete)
+public partial class PlayerController : PawnController
+{
+
+	/// <summary>
+	/// This is temporary, get the hull size for the player's collision
+	/// </summary>
+	public virtual BBox GetHull()
+	{
+		var girth = BodyGirth * 0.5f;
+		var mins = new Vector3( -girth, -girth, 0 );
+		var maxs = new Vector3( +girth, +girth, BodyHeight );
+
+		return new BBox( mins, maxs );
+	}
+
+	protected Vector3 mins;
+	protected Vector3 maxs;
+
+	public virtual void SetBBox( Vector3 mins, Vector3 maxs )
+	{
+		if ( this.mins == mins && this.maxs == maxs )
+			return;
+
+		this.mins = mins;
+		this.maxs = maxs;
+	}
+
+	/// <summary>
+	/// Update the size of the bbox. We should really trigger some shit if this changes.
+	/// </summary>
+	public virtual void UpdateBBox()
+	{
+		var girth = BodyGirth * 0.5f;
+
+		var mins = new Vector3( -girth, -girth, 0 ) * Pawn.Scale;
+		var maxs = new Vector3( +girth, +girth, BodyHeight ) * Pawn.Scale;
+
+		Duck.UpdateBBox( ref mins, ref maxs, Pawn.Scale );
+
+		SetBBox( mins, maxs );
+	}
+
+	protected float SurfaceFriction;
+
+
+	public override void FrameSimulate()
+	{
+		base.FrameSimulate();
+
+		EyeRotation = Input.Rotation;
+	}
+
+	public virtual void WalkMove()
+	{
+		var wishdir = WishVelocity.Normal;
+		var wishspeed = WishVelocity.Length;
+
+		WishVelocity = WishVelocity.WithZ( 0 );
+		WishVelocity = WishVelocity.Normal * wishspeed;
+
+		Velocity = Velocity.WithZ( 0 );
+		Accelerate( wishdir, wishspeed, 0, Acceleration );
+		Velocity = Velocity.WithZ( 0 );
+
+		//   Player.SetAnimParam( "forward", Input.Forward );
+		//   Player.SetAnimParam( "sideward", Input.Right );
+		//   Player.SetAnimParam( "wishspeed", wishspeed );
+		//    Player.SetAnimParam( "walkspeed_scale", 2.0f / 190.0f );
+		//   Player.SetAnimParam( "runspeed_scale", 2.0f / 320.0f );
+
+		//  DebugOverlay.Text( 0, Pos + Vector3.Up * 100, $"forward: {Input.Forward}\nsideward: {Input.Right}" );
+
+		// Add in any base velocity to the current velocity.
+		Velocity += BaseVelocity;
+
+		try
+		{
+			if ( Velocity.Length < 1.0f )
+			{
+				Velocity = Vector3.Zero;
+				return;
+			}
+
+			// first try just moving to the destination
+			var dest = (Position + Velocity * Time.Delta).WithZ( Position.z );
+
+			var pm = TraceBBox( Position, dest );
+
+			if ( pm.Fraction == 1 )
+			{
+				Position = pm.EndPosition;
+				StayOnGround();
+				return;
+			}
+
+			StepMove();
+		}
+		finally
+		{
+
+			// Now pull the base velocity back out.   Base velocity is set if you are on a moving object, like a conveyor (or maybe another monster?)
+			Velocity -= BaseVelocity;
+		}
+
+		StayOnGround();
+	}
+
+	public virtual void StepMove()
+	{
+		var mover = new MoveHelper( Position, Velocity );
+		mover.Trace = mover.Trace.Size( mins, maxs ).Ignore( Pawn );
+		mover.MaxStandableAngle = GroundAngle;
+
+		mover.TryMoveWithStep( Time.Delta, StepSize );
+
+		Position = mover.Position;
+		Velocity = mover.Velocity;
+	}
+
+	public virtual void Move()
+	{
+		var mover = new MoveHelper( Position, Velocity );
+		mover.Trace = mover.Trace.Size( mins, maxs ).Ignore( Pawn );
+		mover.MaxStandableAngle = GroundAngle;
+
+		mover.TryMove( Time.Delta );
+
+		Position = mover.Position;
+		Velocity = mover.Velocity;
+	}
+
+	/// <summary>
+	/// Add our wish direction and speed onto our velocity
+	/// </summary>
+	public virtual void Accelerate( Vector3 wishdir, float wishspeed, float speedLimit, float acceleration )
+	{
+		// This gets overridden because some games (CSPort) want to allow dead (observer) players
+		// to be able to move around.
+		// if ( !CanAccelerate() )
+		//     return;
+
+		if ( speedLimit > 0 && wishspeed > speedLimit )
+			wishspeed = speedLimit;
+
+		// See if we are changing direction a bit
+		var currentspeed = Velocity.Dot( wishdir );
+
+		// Reduce wishspeed by the amount of veer.
+		var addspeed = wishspeed - currentspeed;
+
+		// If not going to add any speed, done.
+		if ( addspeed <= 0 )
+			return;
+
+		// Determine amount of acceleration.
+		var accelspeed = acceleration * Time.Delta * wishspeed * SurfaceFriction;
+
+		// Cap at addspeed
+		if ( accelspeed > addspeed )
+			accelspeed = addspeed;
+
+		Velocity += wishdir * accelspeed;
+	}
+
+	/// <summary>
+	/// Remove ground friction from velocity
+	/// </summary>
+	public virtual void ApplyFriction( float frictionAmount = 1.0f )
+	{
+		// If we are in water jump cycle, don't apply friction
+		//if ( player->m_flWaterJumpTime )
+		//   return;
+
+		// Not on ground - no friction
+
+
+		// Calculate speed
+		var speed = Velocity.Length;
+		if ( speed < 0.1f ) return;
+
+		// Bleed off some speed, but if we have less than the bleed
+		//  threshold, bleed the threshold amount.
+		var control = (speed < StopSpeed) ? StopSpeed : speed;
+
+		// Add the amount to the drop amount.
+		var drop = control * Time.Delta * frictionAmount;
+
+		// scale the velocity
+		var newspeed = speed - drop;
+		if ( newspeed < 0 ) newspeed = 0;
+
+		if ( newspeed != speed )
+		{
+			newspeed /= speed;
+			Velocity *= newspeed;
+		}
+
+		// mv->m_outWishVel -= (1.f-newspeed) * mv->m_vecVelocity;
+	}
+
+	bool _isTouchingLadder = false;
+	Vector3 _ladderNormal;
+
+	public virtual void CheckLadder()
+	{
+		var wishvel = new Vector3( Input.Forward, Input.Left, 0 );
+		wishvel *= Input.Rotation.Angles().WithPitch( 0 ).ToRotation();
+		wishvel = wishvel.Normal;
+
+		if ( _isTouchingLadder )
+		{
+			if ( Input.Pressed( InputButton.Jump ) )
+			{
+				Velocity = _ladderNormal * 100.0f;
+				_isTouchingLadder = false;
+
+				return;
+
+			}
+			else if ( GroundEntity != null && _ladderNormal.Dot( wishvel ) > 0 )
+			{
+				_isTouchingLadder = false;
+
+				return;
+			}
+		}
+
+		const float ladderDistance = 1.0f;
+		var start = Position;
+		var end = start + (_isTouchingLadder ? (_ladderNormal * -1.0f) : wishvel) * ladderDistance;
+
+		var pm = Trace.Ray( start, end )
+					.Size( mins, maxs )
+					.WithTag( "ladder" )
+					.Ignore( Pawn )
+					.Run();
+
+		_isTouchingLadder = false;
+
+		if ( pm.Hit )
+		{
+			_isTouchingLadder = true;
+			_ladderNormal = pm.Normal;
+		}
+	}
+
+	public virtual void LadderMove()
+	{
+		var velocity = WishVelocity;
+		var normalDot = velocity.Dot( _ladderNormal );
+		var cross = _ladderNormal * normalDot;
+		Velocity = (velocity - cross) + (-normalDot * _ladderNormal.Cross( Vector3.Up.Cross( _ladderNormal ).Normal ));
+
+		Move();
+	}
+
+	/// <summary>
+	/// We have a new ground entity
+	/// </summary>
+	public virtual void UpdateGroundEntity( TraceResult tr )
+	{
+		GroundNormal = tr.Normal;
+
+		// VALVE HACKHACK: Scale this to fudge the relationship between vphysics friction values and player friction values.
+		// A value of 0.8f feels pretty normal for vphysics, whereas 1.0f is normal for players.
+		// This scaling trivially makes them equivalent.  REVISIT if this affects low friction surfaces too much.
+		SurfaceFriction = tr.Surface.Friction * 1.25f;
+		if ( SurfaceFriction > 1 ) SurfaceFriction = 1;
+
+		//if ( tr.Entity == GroundEntity ) return;
+
+		Vector3 oldGroundVelocity = default;
+		if ( GroundEntity != null ) oldGroundVelocity = GroundEntity.Velocity;
+
+		bool wasOffGround = GroundEntity == null;
+
+		GroundEntity = tr.Entity;
+
+		if ( GroundEntity != null )
+		{
+			BaseVelocity = GroundEntity.Velocity;
+		}
+	}
+
+	/// <summary>
+	/// We're no longer on the ground, remove it
+	/// </summary>
+	public virtual void ClearGroundEntity()
+	{
+		if ( GroundEntity == null ) return;
+
+		GroundEntity = null;
+		GroundNormal = Vector3.Up;
+		SurfaceFriction = 1.0f;
+	}
+
+	/// <summary>
+	/// Traces the current bbox and returns the result.
+	/// liftFeet will move the start position up by this amount, while keeping the top of the bbox at the same
+	/// position. This is good when tracing down because you won't be tracing through the ceiling above.
+	/// </summary>
+	public virtual TraceResult TraceBBox( Vector3 start, Vector3 end, float liftFeet = 0.0f )
+	{
+		return TraceBBox( start, end, mins, maxs, liftFeet );
+	}
+
+	/// <summary>
+	/// Try to keep a walking player on the ground when running down slopes etc
+	/// </summary>
+	public virtual void StayOnGround()
+	{
+		var start = Position + Vector3.Up * 2;
+		var end = Position + Vector3.Down * StepSize;
+
+		// See how far up we can go without getting stuck
+		var trace = TraceBBox( Position, start );
+		start = trace.EndPosition;
+
+		// Now trace down from a known safe position
+		trace = TraceBBox( start, end );
+
+		if ( trace.Fraction <= 0 ) return;
+		if ( trace.Fraction >= 1 ) return;
+		if ( trace.StartedSolid ) return;
+		if ( Vector3.GetAngle( Vector3.Up, trace.Normal ) > GroundAngle ) return;
+
+		// This is incredibly hacky. The real problem is that trace returning that strange value we can't network over.
+		// float flDelta = fabs( mv->GetAbsOrigin().z - trace.m_vEndPos.z );
+		// if ( flDelta > 0.5f * DIST_EPSILON )
+
+		Position = trace.EndPosition;
+	}
+
+
+	[ConVar.Replicated( "debug_playercontroller" )]
+	public static bool Debug { get; set; } = false;
+
+	/// <summary>
+	/// Any bbox traces we do will be offset by this amount.
+	/// todo: this needs to be predicted
+	/// </summary>
+	public Vector3 TraceOffset;
+
+	/// <summary>
+	/// Traces the bbox and returns the trace result.
+	/// LiftFeet will move the start position up by this amount, while keeping the top of the bbox at the same 
+	/// position. This is good when tracing down because you won't be tracing through the ceiling above.
+	/// </summary>
+	public virtual TraceResult TraceBBox( Vector3 start, Vector3 end, Vector3 mins, Vector3 maxs, float liftFeet = 0.0f )
+	{
+		if ( liftFeet > 0 )
+		{
+			start += Vector3.Up * liftFeet;
+			maxs = maxs.WithZ( maxs.z - liftFeet );
+		}
+
+		var tr = Trace.Ray( start + TraceOffset, end + TraceOffset )
+					.Size( mins, maxs )
+					.WithAnyTags( "solid", "playerclip", "passbullets", "player" )
+					.Ignore( Pawn )
+					.Run();
+
+		tr.EndPosition -= TraceOffset;
+		return tr;
+	}
+
+}

--- a/code/Player/Player.Controller.Base.cs
+++ b/code/Player/Player.Controller.Base.cs
@@ -16,9 +16,21 @@ public partial class PlayerController : PawnController
 	/// </summary>
 	public virtual BBox GetHull()
 	{
-		var girth = BodyGirth * 0.5f;
+		var girth = DefaultWidth * 0.5f;
 		var mins = new Vector3( -girth, -girth, 0 );
-		var maxs = new Vector3( +girth, +girth, BodyHeight );
+		var maxs = new Vector3( +girth, +girth, DefaultHeight );
+
+		return new BBox( mins, maxs );
+	}
+
+	/// <summary>
+	/// This is temporary, get the hull size for the player's collision
+	/// </summary>
+	public virtual BBox GetDuckedHull()
+	{
+		var girth = DefaultWidth * 0.5f;
+		var mins = new Vector3( -girth, -girth, 0 );
+		var maxs = new Vector3( +girth, +girth, DuckHeight );
 
 		return new BBox( mins, maxs );
 	}
@@ -40,13 +52,12 @@ public partial class PlayerController : PawnController
 	/// </summary>
 	public virtual void UpdateBBox()
 	{
-		var girth = BodyGirth * 0.5f;
+		var girth = DefaultWidth * 0.5f;
 
 		var mins = new Vector3( -girth, -girth, 0 ) * Pawn.Scale;
-		var maxs = new Vector3( +girth, +girth, BodyHeight ) * Pawn.Scale;
+		var maxs = new Vector3( +girth, +girth, DefaultHeight ) * Pawn.Scale;
 
-		Duck.UpdateBBox( ref mins, ref maxs, Pawn.Scale );
-
+		UpdateBBox( ref mins, ref maxs, Pawn.Scale );
 		SetBBox( mins, maxs );
 	}
 

--- a/code/Player/Player.Controller.cs
+++ b/code/Player/Player.Controller.cs
@@ -31,7 +31,8 @@ public partial class PlayerController : PawnController
 	public bool Swimming { get; set; } = false;
 	[Net] public bool AutoJump { get; set; } = false;
 
-	public PlayerDuck Duck;
+	[Net, Change]
+	public PlayerDuck Duck { get; private init; }
 	public Unstuck Unstuck;
 
 	[Net, Predicted]

--- a/code/Player/Player.Controller.cs
+++ b/code/Player/Player.Controller.cs
@@ -1,0 +1,418 @@
+﻿
+using Sandbox;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace TTT;
+
+
+public partial class PlayerController : PawnController
+{
+	[Net] public float WalkSpeed { get; set; } = 110.0f;
+	[Net] public float DefaultSpeed { get; set; } = 237.0f;
+	[Net] public float Acceleration { get; set; } = 10.0f;
+	[Net] public float AirAcceleration { get; set; } = 50.0f;
+	[Net] public float FallSoundZ { get; set; } = -30.0f;
+	[Net] public float GroundFriction { get; set; } = 4.0f;
+	[Net] public float StopSpeed { get; set; } = 150.0f;
+	[Net] public float Size { get; set; } = 20.0f;
+	[Net] public float DistEpsilon { get; set; } = 0.03125f;
+	[Net] public float GroundAngle { get; set; } = 46.0f;
+	[Net] public float Bounce { get; set; } = 0.0f;
+	[Net] public float MoveFriction { get; set; } = 1.0f;
+	[Net] public float StepSize { get; set; } = 18.0f;
+	[Net] public float MaxNonJumpVelocity { get; set; } = 140.0f;
+	[Net] public float BodyGirth { get; set; } = 32.0f;
+	[Net] public float BodyHeight { get; set; } = 72.0f;
+	[Net] public float EyeHeight { get; set; } = 64.0f;
+	[Net] public float Gravity { get; set; } = 800.0f;
+	[Net] public float AirControl { get; set; } = 30.0f;
+	public bool Swimming { get; set; } = false;
+	[Net] public bool AutoJump { get; set; } = false;
+
+	public PlayerDuck Duck;
+	public Unstuck Unstuck;
+
+	[Net, Predicted]
+	public bool Momentum { get; set; }
+
+	[Net] public float DuckHeight { get; set; } = 36f;
+	[Net] public float JumpSpeed { get; set; } = 180f;
+
+	private Vector3 _lastBaseVelocity;
+
+	private const float FallDamageThreshold = 650f;
+	private const float FallDamageScale = 0.33f;
+
+
+	public PlayerController()
+	{
+		Duck = new PlayerDuck( this );
+	}
+
+	// public void OnDeactivate();
+	// public void OnActivate();
+
+	public override void Simulate()
+	{
+		_lastBaseVelocity = BaseVelocity;
+
+		ApplyMomentum();
+
+		BaseSimulate();
+
+		// Check for fall damage.
+		var fallVelocity = -Pawn.Velocity.z;
+		if ( GroundEntity is null || fallVelocity <= 0 )
+			return;
+
+		if ( fallVelocity > FallDamageThreshold )
+		{
+			var damage = (MathF.Abs( fallVelocity ) - FallDamageThreshold) * FallDamageScale;
+
+			if ( Host.IsServer )
+			{
+				Pawn.TakeDamage( new DamageInfo
+				{
+					Attacker = Pawn,
+					Flags = DamageFlags.Fall,
+					Force = Vector3.Down * fallVelocity,
+					Damage = damage,
+				} );
+			}
+
+			Pawn.PlaySound( Strings.FallDamageSound ).SetVolume( (damage * 0.05f).Clamp( 0, 0.5f ) );
+		}
+	}
+
+	public virtual void AirMove()
+	{
+		SurfaceFriction = 1f;
+
+		var wishdir = WishVelocity.Normal;
+		var wishspeed = WishVelocity.Length;
+
+		Accelerate( wishdir, wishspeed, AirControl, AirAcceleration );
+
+		Velocity += BaseVelocity;
+
+		Move();
+
+		Velocity -= BaseVelocity;
+	}
+
+	public virtual void CategorizePosition( bool bStayOnGround )
+	{
+		SurfaceFriction = 1.0f;
+
+		// Doing this before we move may introduce a potential latency in water detection, but
+		// doing it after can get us stuck on the bottom in water if the amount we move up
+		// is less than the 1 pixel 'threshold' we're about to snap to.	Also, we'll call
+		// this several times per frame, so we really need to avoid sticking to the bottom of
+		// water on each call, and the converse case will correct itself if called twice.
+		//CheckWater();
+
+		var point = Position - Vector3.Up * 2;
+		var vBumpOrigin = Position;
+
+		//
+		//  Shooting up really fast.  Definitely not on ground trimed until ladder shit
+		//
+		var bMovingUpRapidly = Velocity.z + _lastBaseVelocity.z > MaxNonJumpVelocity;
+		var bMoveToEndPos = false;
+
+		if ( GroundEntity != null ) // and not underwater
+		{
+			bMoveToEndPos = true;
+			point.z -= StepSize;
+		}
+		else if ( bStayOnGround )
+		{
+			bMoveToEndPos = true;
+			point.z -= StepSize;
+		}
+
+		if ( bMovingUpRapidly || Swimming ) // or ladder and moving up
+		{
+			ClearGroundEntity();
+			return;
+		}
+
+		var pm = TraceBBox( vBumpOrigin, point, 4.0f );
+
+		if ( pm.Entity == null || Vector3.GetAngle( Vector3.Up, pm.Normal ) > GroundAngle )
+		{
+			ClearGroundEntity();
+			bMoveToEndPos = false;
+
+			if ( Velocity.z + _lastBaseVelocity.z > 0 )
+				SurfaceFriction = 0.25f;
+		}
+		else
+		{
+			UpdateGroundEntity( pm );
+		}
+
+		if ( bMoveToEndPos && !pm.StartedSolid && pm.Fraction > 0.0f && pm.Fraction < 1.0f )
+		{
+			Position = pm.EndPosition;
+		}
+	}
+
+	public virtual float GetWishSpeed()
+	{
+		var ws = Duck.GetWishSpeed();
+
+		if ( ws >= 0 )
+			return ws;
+
+		if ( Input.Down( InputButton.Run ) )
+			return WalkSpeed;
+
+		return DefaultSpeed;
+	}
+
+	public void LimitSpeed()
+	{
+		var prevz = Velocity.z;
+		BaseVelocity = 0;
+		Velocity = Velocity.WithZ( 0 ).ClampLength( 290 );
+		Velocity = Velocity.WithZ( prevz );
+	}
+
+	private void ApplyMomentum()
+	{
+		if ( !Momentum )
+		{
+			Velocity += (1.0f + (Time.Delta * 0.5f)) * BaseVelocity;
+			BaseVelocity = Vector3.Zero;
+		}
+
+		Momentum = false;
+	}
+
+	private void BaseSimulate()
+	{
+		UpdateView();
+		CheckLadder();
+		Swimming = Pawn.WaterLevel > 0.6f;
+
+		if ( !Swimming /*&& !IsTouchingLadder */)
+		{
+			Velocity -= new Vector3( 0, 0, Gravity * 0.5f ) * Time.Delta;
+			Velocity += new Vector3( 0, 0, BaseVelocity.z ) * Time.Delta;
+
+			BaseVelocity = BaseVelocity.WithZ( 0 );
+		}
+
+		if ( AutoJump ? Input.Down( InputButton.Jump ) : Input.Pressed( InputButton.Jump ) )
+		{
+			CheckJumpButton();
+		}
+
+		var bStartOnGround = GroundEntity != null;
+		if ( bStartOnGround )
+		{
+			Velocity = Velocity.WithZ( 0 );
+
+			if ( GroundEntity != null )
+			{
+				ApplyFriction( GroundFriction * SurfaceFriction );
+			}
+		}
+
+		WishVelocity = new Vector3( Input.Forward, Input.Left, 0 );
+		var inSpeed = WishVelocity.Length.Clamp( 0, 1 );
+
+		if ( !Swimming )
+		{
+			WishVelocity *= Input.Rotation.Angles().WithPitch( 0 ).ToRotation();
+		}
+		else
+		{
+			WishVelocity *= Input.Rotation.Angles().ToRotation();
+		}
+
+
+		if ( !Swimming/* && !IsTouchingLadder*/ )
+		{
+			WishVelocity = WishVelocity.WithZ( 0 );
+		}
+
+		WishVelocity = WishVelocity.Normal * inSpeed;
+		WishVelocity *= GetWishSpeed();
+
+		Duck.PreTick();
+
+		var bStayOnGround = false;
+		if ( Swimming )
+		{
+			if ( Pawn.WaterLevel.AlmostEqual( 0.6f, .05f ) )
+				CheckWaterJump();
+
+			WaterMove();
+		}
+		//else if ( IsTouchingLadder )
+		//{
+		//	LadderMove();
+		//}
+		else if ( GroundEntity != null )
+		{
+			bStayOnGround = true;
+			WalkMove();
+		}
+		else
+		{
+			AirMove();
+		}
+
+		CategorizePosition( bStayOnGround );
+
+		// FinishGravity
+		if ( !Swimming/* && !IsTouchingLadder*/ )
+		{
+			Velocity -= new Vector3( 0, 0, Gravity * 0.5f ) * Time.Delta;
+		}
+
+		if ( GroundEntity != null )
+		{
+			Velocity = Velocity.WithZ( 0 );
+		}
+	}
+
+	public virtual void CheckJumpButton()
+	{
+		if ( Swimming )
+		{
+			ClearGroundEntity();
+
+			Velocity = Velocity.WithZ( 100 );
+			return;
+		}
+
+		if ( GroundEntity == null )
+			return;
+
+		ClearGroundEntity();
+
+		Velocity = Velocity.WithZ( JumpSpeed );
+		// Velocity -= new Vector3( 0, 0, Gravity * 0.5f ) * Time.Delta;
+
+		AddEvent( "jump" );
+	}
+
+	[Net, Predicted]
+	public TimeSince TimeSinceWaterJump { get; set; }
+	private void CheckWaterJump()
+	{
+		if ( !Input.Down( InputButton.Jump ) )
+			return;
+
+		if ( TimeSinceWaterJump < 2f )
+			return;
+
+		if ( Velocity.z < -180 )
+			return;
+
+		var fwd = Rotation * Vector3.Forward;
+		var flatvelocity = Velocity.WithZ( 0 );
+		var curspeed = flatvelocity.Length;
+		flatvelocity = flatvelocity.Normal;
+		var flatforward = fwd.WithZ( 0 ).Normal;
+
+		// Are we backing into water from steps or something?  If so, don't pop forward
+		if ( !curspeed.AlmostEqual( 0f ) && (Vector3.Dot( flatvelocity, flatforward ) < 0f) )
+			return;
+
+		var vecstart = Position + (mins + maxs) * .5f;
+		var vecend = vecstart + flatforward * 24f;
+
+		var tr = TraceBBox( vecstart, vecend, 0f );
+		if ( tr.Fraction < 1.0f )
+		{
+			const float WATERJUMP_HEIGHT = 8f;
+			vecstart.z += Position.z + EyeHeight + WATERJUMP_HEIGHT;
+
+			vecend = vecstart + flatforward * 24f;
+
+			tr = TraceBBox( vecstart, vecend );
+			if ( tr.Fraction == 1.0f )
+			{
+				vecstart = vecend;
+				vecend.z -= 1024f;
+				tr = TraceBBox( vecstart, vecend );
+				if ( (tr.Fraction < 1.0f) && (tr.Normal.z >= 0.7f) )
+				{
+					Velocity = Velocity.WithZ( 356f );
+					TimeSinceWaterJump = 0f;
+				}
+			}
+		}
+	}
+
+	public virtual void WaterMove()
+	{
+		var wishvel = WishVelocity;
+
+		if ( Input.Down( InputButton.Jump ) )
+		{
+			wishvel[2] += DefaultSpeed;
+		}
+		else if ( wishvel.IsNearlyZero() )
+		{
+			wishvel[2] -= 40f;
+		}
+		else
+		{
+			var upwardMovememnt = Input.Forward * (Rotation * Vector3.Forward).z * 2;
+			upwardMovememnt = Math.Clamp( upwardMovememnt, 0f, DefaultSpeed );
+			wishvel[2] += Input.Up + upwardMovememnt;
+		}
+
+		var speed = Velocity.Length;
+		var wishspeed = Math.Min( wishvel.Length, DefaultSpeed ); // * 0.8f;
+		var wishdir = wishvel.Normal;
+
+		if ( speed > 0 )
+		{
+			var newspeed = speed - Time.Delta * speed * GroundFriction * SurfaceFriction;
+			if ( newspeed < 0.1f )
+			{
+				newspeed = 0;
+			}
+
+			Velocity *= newspeed / speed;
+		}
+
+		if ( wishspeed >= 0.1f )  // old !
+		{
+			Accelerate( wishdir, wishspeed, 100, Acceleration );
+		}
+
+		Velocity += BaseVelocity;
+
+		Move();
+
+		Velocity -= BaseVelocity;
+	}
+
+	/// <summary>
+	/// Calculate the orientation of the view from the hull.
+	/// </summary>
+	public void UpdateView( bool snapCamera = false )
+	{
+		// var eyeZ = Duck.Ducked ? DuckHeight - (BodyHeight - EyeHeight) : EyeHeight;
+		var eyeZ = Duck.EyeHeight();
+		EyeLocalPosition = Vector3.Up * (eyeZ * Pawn.Scale);
+
+		UpdateBBox();
+		EyeLocalPosition += TraceOffset;
+		EyeRotation = Input.Rotation;
+
+		if ( snapCamera )
+			this.Pawn.ResetInterpolation();
+	}
+
+}
+

--- a/code/Player/Player.Duck.cs
+++ b/code/Player/Player.Duck.cs
@@ -59,7 +59,6 @@ public partial class PlayerController : PawnController
 				else
 					DuckFraction = Math.Clamp( DuckFraction - duckDelta, 0, 1 );
 
-
 				if ( DuckFraction.AlmostEqual( 0 ) )
 					UnDuck();
 			}
@@ -85,11 +84,11 @@ public partial class PlayerController : PawnController
 		{
 			DuckHoldUntil = DuckHoldTime;
 
-			var distToCeil = TraceBBox( Position, Position + (Vector3.Up * DefaultHeight * 2f) ).Distance;
-			var shift = MathF.Min( distToCeil, DuckHullOffset() );
+			// var distToCeil = TraceBBox( Position, Position + (Vector3.Up * DefaultHeight * 2f) ).Distance;
+			// var shift = MathF.Min( distToCeil, DuckHullOffset() );
 
-			Position += Vector3.Up * shift;
-			UpdateView( snapCamera: true );
+			// Position += Vector3.Up * shift;
+			// UpdateView( snapCamera: true );
 		}
 	}
 
@@ -116,14 +115,14 @@ public partial class PlayerController : PawnController
 		UpdateBBox();
 
 		// Extend legs downward only if airborne.
-		if ( GroundEntity == null )
+		/*if ( GroundEntity == null )
 		{
 			var distToGround = TraceBBox( Position, Position + Vector3.Down * DefaultHeight * 2f ).Distance;
 			var shift = MathF.Min( DuckHullOffset(), distToGround );
 
 			Position += Vector3.Down * shift;
 			UpdateView( snapCamera: true );
-		}
+		}*/
 	}
 
 	public float ActiveEyeHeight()

--- a/code/Player/Player.Duck.cs
+++ b/code/Player/Player.Duck.cs
@@ -15,19 +15,19 @@ public partial class PlayerDuck : BaseNetworkable
 	/// <summary> Is the player in a fully completed duck state? </summary>
 	// [Net]
 	// [Predicted]
-	// [Net, Predicted]
+	[Net, Predicted]
 	public bool Ducked { get; private set; } = false;
 	// [Net]
 	// [Predicted]
-	// [Net, Predicted]
+	[Net, Predicted]
 	public float Fraction { get; private set; } = 0f;
-	// [Net]
+	[Net]
 	public float ToggleSpeed { get; set; } = 7.0f;
 
-	// [Net]
+	[Net]
 	public float StuckDelay { get; set; } = 0.72f;
 	// [Predicted]
-	// [Net, Predicted]
+	[Net, Predicted]
 	public TimeUntil StuckUntil { get; private set; }
 
 
@@ -57,12 +57,14 @@ public partial class PlayerDuck : BaseNetworkable
 			// Ducking.
 			if ( !Ducked || Fraction < 1 )
 			{
-				if ( Prediction.FirstTime ) //Host.IsClient )
+				// if ( Prediction.FirstTime )
+				if ( Prediction.FirstTime && Host.IsClient )
 					Log.Info( $"[{Host.Name}] FractionBefore: {Fraction}" );
 
 				Fraction = Math.Clamp( Fraction + duckDelta, 0, 1 );
 
-				if ( Prediction.FirstTime ) //Host.IsClient )
+				// if ( Prediction.FirstTime )
+				if ( Prediction.FirstTime && Host.IsClient )
 					Log.Info( $"[{Host.Name}] FractionAfter: {Fraction}" );
 
 				if ( Fraction.AlmostEqual( 1 ) )
@@ -74,13 +76,15 @@ public partial class PlayerDuck : BaseNetworkable
 			// Standing.
 			if ( Ducked || Fraction > 0 )
 			{
-				if ( Prediction.FirstTime ) //Host.IsClient )
+				// if ( Prediction.FirstTime )
+				if ( Prediction.FirstTime && Host.IsClient )
 					Log.Info( $"[{Host.Name}] FractionBefore: {Fraction}" );
 
 				// TODO: Reapply duck if there's no room to unduck.
 				Fraction = Math.Clamp( Fraction - duckDelta, 0, 1 );
 
-				if ( Prediction.FirstTime ) //Host.IsClient )
+				// if ( Prediction.FirstTime )
+				if ( Prediction.FirstTime && Host.IsClient )
 					Log.Info( $"[{Host.Name}] FractionAfter: {Fraction}" );
 
 				if ( Fraction.AlmostEqual( 0 ) )

--- a/code/Player/Player.Duck.cs
+++ b/code/Player/Player.Duck.cs
@@ -7,166 +7,137 @@ using System;
 namespace TTT;
 
 
-[Library]
-public partial class PlayerDuck : BaseNetworkable
+public partial class PlayerController : PawnController
 {
-	public PlayerController Walk;
-
 	/// <summary> Is the player in a fully completed duck state? </summary>
-	// [Net]
-	// [Predicted]
 	[Net, Predicted]
 	public bool Ducked { get; private set; } = false;
-	// [Net]
-	// [Predicted]
 	[Net, Predicted]
-	public float Fraction { get; private set; } = 0f;
-	[Net]
-	public float ToggleSpeed { get; set; } = 7.0f;
+	public float DuckFraction { get; private set; } = 0f;
 
-	[Net]
-	public float StuckDelay { get; set; } = 0.72f;
-	// [Predicted]
+	[Net] public float DuckToggleSpeed { get; set; } = 7.0f;
+	[Net] public float DuckHoldTime { get; set; } = 0.72f;
+
 	[Net, Predicted]
-	public TimeUntil StuckUntil { get; private set; }
+	public TimeUntil DuckHoldUntil { get; private set; }
 
 
-	public PlayerDuck( PlayerController controller )
-	{
-		Walk = controller;
-	}
-
-	public virtual void PreTick()
+	public virtual void DuckPreTick()
 	{
 		var shouldDuck = Input.Down( InputButton.Duck );
-		var onGround = Walk.GroundEntity != null;
+		var onGround = GroundEntity != null;
 
-		// Prevent cheap duck spamming exploit in the air.
-		if (StuckUntil > 0)
+		// Prevent cheap duck spamming exploit while airborne.
+		if ( DuckHoldUntil > 0 )
 		{
-			Log.Info( $"[{Host.Name}] StuckUntil: {StuckUntil}" );
-			if (onGround) StuckUntil = 0;
+			if ( onGround ) DuckHoldUntil = 0;
 			else shouldDuck = true;
 		}
 
 		// Toggle instantly if airborne.
-		var duckDelta = onGround ? ToggleSpeed * Time.Delta : 999;
+		var duckDelta = onGround ? DuckToggleSpeed * Time.Delta : 999;
 
 		if ( shouldDuck )
 		{
 			// Ducking.
-			if ( !Ducked || Fraction < 1 )
+			if ( !Ducked || DuckFraction < 1 )
 			{
-				// if ( Prediction.FirstTime )
-				if ( Prediction.FirstTime && Host.IsClient )
-					Log.Info( $"[{Host.Name}] FractionBefore: {Fraction}" );
+				DuckFraction = Math.Clamp( DuckFraction + duckDelta, 0, 1 );
 
-				Fraction = Math.Clamp( Fraction + duckDelta, 0, 1 );
-
-				// if ( Prediction.FirstTime )
-				if ( Prediction.FirstTime && Host.IsClient )
-					Log.Info( $"[{Host.Name}] FractionAfter: {Fraction}" );
-
-				if ( Fraction.AlmostEqual( 1 ) )
+				if ( DuckFraction.AlmostEqual( 1 ) )
 					Duck();
 			}
 		}
 		else
 		{
 			// Standing.
-			if ( Ducked || Fraction > 0 )
+			if ( Ducked || DuckFraction > 0 )
 			{
-				// if ( Prediction.FirstTime )
-				if ( Prediction.FirstTime && Host.IsClient )
-					Log.Info( $"[{Host.Name}] FractionBefore: {Fraction}" );
+				// Stay ducked if there's no room to unduck.
+				if ( !CanUnDuck() )
+					DuckFraction = 1f;
+				else
+					DuckFraction = Math.Clamp( DuckFraction - duckDelta, 0, 1 );
 
-				// TODO: Reapply duck if there's no room to unduck.
-				Fraction = Math.Clamp( Fraction - duckDelta, 0, 1 );
 
-				// if ( Prediction.FirstTime )
-				if ( Prediction.FirstTime && Host.IsClient )
-					Log.Info( $"[{Host.Name}] FractionAfter: {Fraction}" );
-
-				if ( Fraction.AlmostEqual( 0 ) )
+				if ( DuckFraction.AlmostEqual( 0 ) )
 					UnDuck();
 			}
 		}
 
 		// Animation
 		if ( Ducked )
-			Walk.SetTag( "ducked" );
-	}
-
-	public bool InProgress()
-	{
-		return (Ducked && Fraction < 1f) || (!Ducked && Fraction > 0f);
+			SetTag( "ducked" );
 	}
 
 	public void Duck()
 	{
 		if ( Ducked ) return;
-		Log.Info( $"[{Host.Name}] Ducked" );
+		// Log.Info( $"[{Host.Name}] Ducked" );
 
 		Ducked = true;
-		Fraction = 1;
+		DuckFraction = 1;
 
-		Walk.UpdateBBox();
+		UpdateBBox();
 
 		// Tuck legs upward only if airborne.
-		if ( Walk.GroundEntity == null )
+		if ( GroundEntity == null )
 		{
-			StuckUntil = StuckDelay;
-			Log.Info( $"[{Host.Name}] Skill ceiling lowered: {StuckUntil}" );
+			DuckHoldUntil = DuckHoldTime;
 
-			var distToCeil = Walk.TraceBBox( Walk.Position, Walk.Position + (Vector3.Up * Walk.BodyHeight * 2f) ).Distance;
+			var distToCeil = TraceBBox( Position, Position + (Vector3.Up * DefaultHeight * 2f) ).Distance;
 			var shift = MathF.Min( distToCeil, DuckHullOffset() );
 
-			Walk.Position += Vector3.Up * shift;
-			Walk.UpdateView( snapCamera: true );
+			Position += Vector3.Up * shift;
+			UpdateView( snapCamera: true );
 		}
+	}
+
+	/// <summary>
+	/// Is there something in the way of us unducking?
+	/// </summary>
+	public bool CanUnDuck()
+	{
+		var hull = GetHull();
+		return !TraceBBox( Position, Position, hull.Mins, hull.Maxs ).StartedSolid;
 	}
 
 	public void UnDuck()
 	{
 		if ( !Ducked ) return;
-		Log.Info( $"[{Host.Name}] Un-Ducked" );
+		// Log.Info( $"[{Host.Name}] Un-Ducked" );
 
-		// Don't unduck if stuck.
-		var pm = Walk.TraceBBox( Walk.Position, Walk.Position, _mins, _maxs );
-		if ( pm.StartedSolid ) return;
+		if ( !CanUnDuck() )
+			return;
 
 		Ducked = false;
-		Fraction = 0;
+		DuckFraction = 0;
 
-		Walk.UpdateBBox();
+		UpdateBBox();
 
 		// Extend legs downward only if airborne.
-		if ( Walk.GroundEntity == null )
+		if ( GroundEntity == null )
 		{
-			var distToGround = Walk.TraceBBox( Walk.Position, Walk.Position + Vector3.Down * Walk.BodyHeight * 2f ).Distance;
+			var distToGround = TraceBBox( Position, Position + Vector3.Down * DefaultHeight * 2f ).Distance;
 			var shift = MathF.Min( DuckHullOffset(), distToGround );
 
-			Walk.Position += Vector3.Down * shift;
-			Walk.UpdateView( snapCamera: true );
+			Position += Vector3.Down * shift;
+			UpdateView( snapCamera: true );
 		}
 	}
 
-	public virtual float GetWishSpeed()
+	public float ActiveEyeHeight()
 	{
-		if ( !Ducked ) return -1f;
-		return 93f;
+		var eyeOffset = DefaultHeight - EyeHeight;
+		var zStand = DefaultHeight - eyeOffset;
+		var zDuck = DuckHeight - eyeOffset;
+
+		return zDuck + ((zStand - zDuck) * (1 - DuckFraction));
 	}
 
-	public float EyeHeight()
+	public float DuckHullOffset()
 	{
-		var eyeOffset = Walk.BodyHeight - Walk.EyeHeight;
-		var zStand = Walk.BodyHeight - eyeOffset;
-		var zDuck = Walk.DuckHeight - eyeOffset;
-
-		// No built-in lerp method. What the fuck?
-		// var frac = Ducked ? 1 : 0;
-		// return zDuck + ((zStand - zDuck) * (1 - frac));
-		return zDuck + ((zStand - zDuck) * (1 - Fraction));
+		return MathF.Max( DefaultHeight - DuckHeight, 0f );
 	}
 
 	Vector3 _mins = Vector3.Zero;
@@ -178,12 +149,7 @@ public partial class PlayerDuck : BaseNetworkable
 		_maxs = maxs;
 
 		if ( Ducked )
-			maxs = maxs.WithZ( Walk.DuckHeight * scale );
-	}
-
-	public float DuckHullOffset()
-	{
-		return MathF.Max( Walk.BodyHeight - Walk.DuckHeight, 0f );
+			maxs = maxs.WithZ( DuckHeight * scale );
 	}
 
 }

--- a/code/Player/Player.Duck.cs
+++ b/code/Player/Player.Duck.cs
@@ -1,0 +1,185 @@
+﻿
+using System.Threading;
+using System.Numerics;
+using Sandbox;
+using System;
+
+namespace TTT;
+
+
+[Library]
+public partial class PlayerDuck : BaseNetworkable
+{
+	public PlayerController Walk;
+
+	/// <summary> Is the player in a fully completed duck state? </summary>
+	// [Net]
+	// [Predicted]
+	// [Net, Predicted]
+	public bool Ducked { get; private set; } = false;
+	// [Net]
+	// [Predicted]
+	// [Net, Predicted]
+	public float Fraction { get; private set; } = 0f;
+	// [Net]
+	public float ToggleSpeed { get; set; } = 7.0f;
+
+	// [Net]
+	public float StuckDelay { get; set; } = 0.72f;
+	// [Predicted]
+	// [Net, Predicted]
+	public TimeUntil StuckUntil { get; private set; }
+
+
+	public PlayerDuck( PlayerController controller )
+	{
+		Walk = controller;
+	}
+
+	public virtual void PreTick()
+	{
+		var shouldDuck = Input.Down( InputButton.Duck );
+		var onGround = Walk.GroundEntity != null;
+
+		// Prevent cheap duck spamming exploit in the air.
+		if (StuckUntil > 0)
+		{
+			Log.Info( $"[{Host.Name}] StuckUntil: {StuckUntil}" );
+			if (onGround) StuckUntil = 0;
+			else shouldDuck = true;
+		}
+
+		// Toggle instantly if airborne.
+		var duckDelta = onGround ? ToggleSpeed * Time.Delta : 999;
+
+		if ( shouldDuck )
+		{
+			// Ducking.
+			if ( !Ducked || Fraction < 1 )
+			{
+				if ( Prediction.FirstTime ) //Host.IsClient )
+					Log.Info( $"[{Host.Name}] FractionBefore: {Fraction}" );
+
+				Fraction = Math.Clamp( Fraction + duckDelta, 0, 1 );
+
+				if ( Prediction.FirstTime ) //Host.IsClient )
+					Log.Info( $"[{Host.Name}] FractionAfter: {Fraction}" );
+
+				if ( Fraction.AlmostEqual( 1 ) )
+					Duck();
+			}
+		}
+		else
+		{
+			// Standing.
+			if ( Ducked || Fraction > 0 )
+			{
+				if ( Prediction.FirstTime ) //Host.IsClient )
+					Log.Info( $"[{Host.Name}] FractionBefore: {Fraction}" );
+
+				// TODO: Reapply duck if there's no room to unduck.
+				Fraction = Math.Clamp( Fraction - duckDelta, 0, 1 );
+
+				if ( Prediction.FirstTime ) //Host.IsClient )
+					Log.Info( $"[{Host.Name}] FractionAfter: {Fraction}" );
+
+				if ( Fraction.AlmostEqual( 0 ) )
+					UnDuck();
+			}
+		}
+
+		// Animation
+		if ( Ducked )
+			Walk.SetTag( "ducked" );
+	}
+
+	public bool InProgress()
+	{
+		return (Ducked && Fraction < 1f) || (!Ducked && Fraction > 0f);
+	}
+
+	public void Duck()
+	{
+		if ( Ducked ) return;
+		Log.Info( $"[{Host.Name}] Ducked" );
+
+		Ducked = true;
+		Fraction = 1;
+
+		Walk.UpdateBBox();
+
+		// Tuck legs upward only if airborne.
+		if ( Walk.GroundEntity == null )
+		{
+			StuckUntil = StuckDelay;
+			Log.Info( $"[{Host.Name}] Skill ceiling lowered: {StuckUntil}" );
+
+			var distToCeil = Walk.TraceBBox( Walk.Position, Walk.Position + (Vector3.Up * Walk.BodyHeight * 2f) ).Distance;
+			var shift = MathF.Min( distToCeil, DuckHullOffset() );
+
+			Walk.Position += Vector3.Up * shift;
+			Walk.UpdateView( snapCamera: true );
+		}
+	}
+
+	public void UnDuck()
+	{
+		if ( !Ducked ) return;
+		Log.Info( $"[{Host.Name}] Un-Ducked" );
+
+		// Don't unduck if stuck.
+		var pm = Walk.TraceBBox( Walk.Position, Walk.Position, _mins, _maxs );
+		if ( pm.StartedSolid ) return;
+
+		Ducked = false;
+		Fraction = 0;
+
+		Walk.UpdateBBox();
+
+		// Extend legs downward only if airborne.
+		if ( Walk.GroundEntity == null )
+		{
+			var distToGround = Walk.TraceBBox( Walk.Position, Walk.Position + Vector3.Down * Walk.BodyHeight * 2f ).Distance;
+			var shift = MathF.Min( DuckHullOffset(), distToGround );
+
+			Walk.Position += Vector3.Down * shift;
+			Walk.UpdateView( snapCamera: true );
+		}
+	}
+
+	public virtual float GetWishSpeed()
+	{
+		if ( !Ducked ) return -1f;
+		return 93f;
+	}
+
+	public float EyeHeight()
+	{
+		var eyeOffset = Walk.BodyHeight - Walk.EyeHeight;
+		var zStand = Walk.BodyHeight - eyeOffset;
+		var zDuck = Walk.DuckHeight - eyeOffset;
+
+		// No built-in lerp method. What the fuck?
+		// var frac = Ducked ? 1 : 0;
+		// return zDuck + ((zStand - zDuck) * (1 - frac));
+		return zDuck + ((zStand - zDuck) * (1 - Fraction));
+	}
+
+	Vector3 _mins = Vector3.Zero;
+	Vector3 _maxs = Vector3.Zero;
+
+	public virtual void UpdateBBox( ref Vector3 mins, ref Vector3 maxs, float scale )
+	{
+		_mins = mins;
+		_maxs = maxs;
+
+		if ( Ducked )
+			maxs = maxs.WithZ( Walk.DuckHeight * scale );
+	}
+
+	public float DuckHullOffset()
+	{
+		return MathF.Max( Walk.BodyHeight - Walk.DuckHeight, 0f );
+	}
+
+}

--- a/code/Player/Player.cs
+++ b/code/Player/Player.cs
@@ -106,7 +106,20 @@ public partial class Player : AnimatedEntity
 			EnableDrawing = true;
 			EnableTouch = true;
 
-			Controller = new WalkController();
+			Controller = new PlayerController()
+			{
+				AirAcceleration = 65f, //1500f,
+				WalkSpeed = 110f,
+				DefaultSpeed = 230f,
+				StopSpeed = 105f,
+				Acceleration = 8f,
+				GroundFriction = 5,
+				AutoJump = false,
+				// Matches HL2 according to 'test/scale` map.
+				JumpSpeed = 180f,
+				Gravity = 800f,
+			};
+
 			Camera = new FirstPersonCamera();
 
 			CreateHull();
@@ -284,7 +297,7 @@ public partial class Player : AnimatedEntity
 
 	#region Controller
 	[Net, Predicted]
-	public PawnController Controller { get; set; }
+	public PlayerController Controller { get; set; }
 
 	[Net, Predicted]
 	public PawnController DevController { get; set; }

--- a/code/Player/Player.cs
+++ b/code/Player/Player.cs
@@ -115,9 +115,12 @@ public partial class Player : AnimatedEntity
 				Acceleration = 8f,
 				GroundFriction = 5,
 				AutoJump = false,
+				// Custom values.
+				JumpSpeed = 325f,
+				Gravity = 800,
 				// Matches HL2 according to 'test/scale` map.
-				JumpSpeed = 180f,
-				Gravity = 800f,
+				// Gravity = 800f,
+				// JumpSpeed = 180f,
 			};
 
 			Camera = new FirstPersonCamera();


### PR DESCRIPTION
### Summary
A character controller copied from the Strafe gamemode by Facepunch and edited by myself to hopefully look and feel very much like GMod TTT player physics. Plus a couple features to make things more fair.

### Improvements (from the default)
- **Duck Transitioning**
You will smoothly go from standing to ducking while on the ground. The animation does not change until you fully toggle your state.
- **Overhead Unduck Checking**
You won't unduck when it would cause you to get stuck or make your model look like it would be.
- **HL2 Style Airduck**
Your hitbox will actually shrink from below, instantly, allowing you to jump over stuff super easily.
- **Jumpduck Spam Prevention**
You can no longer press the duck key many times in the air during a jump to teleport your model(along with your hitboxes) up and down in a super obnoxious way. You're stuck ducking only for as long as an average jump would last.
Video example of exploit: https://streamable.com/s0matf
- **Bunnyhop Dampening**
If you are moving faster than the default speed(plus a bit extra) then it will dampen some of that excess speed.
As a result, you can move somewhat faster if you're good at bhopping but can't maintain insane speeds. Easily tweaked.

### Problems
- Interacting with physics props still needs some work. Seems to be a common problem with character controllers, though.