### PR TITLE
Fix: Using entities is inconsistent

### DIFF
--- a/code/Player/Player.Hints.cs
+++ b/code/Player/Player.Hints.cs
@@ -57,6 +57,7 @@ public partial class Player
 			.Run();
 
 		HoveredEntity = trace.Entity;
+		HoveredEntityDistance = trace.Distance;
 
 		if ( HoveredEntity is IEntityHint hint && trace.Distance <= hint.HintDistance )
 			return hint;

--- a/code/Player/Player.Hints.cs
+++ b/code/Player/Player.Hints.cs
@@ -57,7 +57,6 @@ public partial class Player
 			.Run();
 
 		HoveredEntity = trace.Entity;
-		HoveredEntityDistance = trace.Distance;
 
 		if ( HoveredEntity is IEntityHint hint && trace.Distance <= hint.HintDistance )
 			return hint;

--- a/code/Player/Player.Use.cs
+++ b/code/Player/Player.Use.cs
@@ -11,9 +11,9 @@ public partial class Player
 	/// The entity we're currently looking at.
 	/// </summary>
 	public Entity HoveredEntity { get; private set; }
-	public float HoveredEntityDistance { get; private set; }
 
 	public const float UseDistance = 80f;
+	private float _traceDistance;
 
 	protected void PlayerUse()
 	{
@@ -55,8 +55,8 @@ public partial class Player
 		if ( trace.Entity.IsWorld )
 			return null;
 
-		HoveredEntityDistance = trace.Distance;
-		return HoveredEntity = trace.Entity;
+		_traceDistance = trace.Distance;
+		return trace.Entity;
 	}
 
 	public bool CanUse( Entity entity )
@@ -64,7 +64,7 @@ public partial class Player
 		if ( entity is not IUse use )
 			return false;
 
-		if ( HoveredEntityDistance > UseDistance )
+		if ( _traceDistance > UseDistance )
 			return false;
 
 		if ( !use.IsUsable( this ) )
@@ -76,6 +76,9 @@ public partial class Player
 	public bool CanContinueUsing( Entity entity )
 	{
 		if ( HoveredEntity != entity )
+			return false;
+
+		if ( _traceDistance > UseDistance )
 			return false;
 
 		if ( entity is IUse use && use.OnUse( this ) )

--- a/code/Player/Player.Use.cs
+++ b/code/Player/Player.Use.cs
@@ -11,6 +11,7 @@ public partial class Player
 	/// The entity we're currently looking at.
 	/// </summary>
 	public Entity HoveredEntity { get; private set; }
+	public float HoveredEntityDistance { get; private set; }
 
 	public const float UseDistance = 80f;
 
@@ -54,7 +55,8 @@ public partial class Player
 		if ( trace.Entity.IsWorld )
 			return null;
 
-		return trace.Entity;
+		HoveredEntityDistance = trace.Distance;
+		return HoveredEntity = trace.Entity;
 	}
 
 	public bool CanUse( Entity entity )
@@ -62,7 +64,7 @@ public partial class Player
 		if ( entity is not IUse use )
 			return false;
 
-		if ( entity.Position.Distance( EyePosition ) > UseDistance )
+		if ( HoveredEntityDistance > UseDistance )
 			return false;
 
 		if ( !use.IsUsable( this ) )


### PR DESCRIPTION
When using an entity, TTT currently checks the distance between the player's eye position and the entity's origin. This makes TTT check the distance of the trace used to find the entity instead.

Doors are heavily affected by this since their origin is at their hinge instead of the center of their model.