### PR TITLE
Fix: Remove mouse smoothing from spectator cameras

### DIFF
--- a/code/Player/Cameras/FirstPersonSpectatorCamera.cs
+++ b/code/Player/Cameras/FirstPersonSpectatorCamera.cs
@@ -23,15 +23,11 @@ public class FirstPersonSpectatorCamera : CameraMode, ISpectateCamera
 		if ( Local.Pawn is not Player player )
 			return;
 
-		Viewer = player;
 		player.CurrentPlayer = null;
 	}
 
 	public override void Update()
 	{
-		if ( Local.Pawn is not Player player )
-			return;
-
 		Position = Vector3.Lerp( Position, Viewer.EyePosition, SmoothSpeed * Time.Delta );
 		Rotation = Rotation.Slerp( Rotation, Viewer.EyeRotation, SmoothSpeed * Time.Delta );
 	}

--- a/code/Player/Cameras/FollowEntityCamera.cs
+++ b/code/Player/Cameras/FollowEntityCamera.cs
@@ -1,4 +1,4 @@
-﻿using Sandbox;
+using Sandbox;
 
 namespace TTT;
 
@@ -21,8 +21,6 @@ public partial class FollowEntityCamera : CameraMode, ISpectateCamera
 
 		Position = CurrentView.Position;
 		Rotation = CurrentView.Rotation;
-
-		Viewer = null;
 	}
 
 	public override void Update()

--- a/code/Player/Cameras/FollowEntityCamera.cs
+++ b/code/Player/Cameras/FollowEntityCamera.cs
@@ -30,15 +30,15 @@ public partial class FollowEntityCamera : CameraMode, ISpectateCamera
 		if ( !FollowedEntity.IsValid() )
 			return;
 
-		_focusPoint = Vector3.Lerp( _focusPoint, FollowedEntity.Position, Time.Delta * 5.0f );
-
 		Rotation = Input.Rotation;
 
-		var trace = Trace.Ray( FollowedEntity.Position, _focusPoint + GetViewOffset() )
+		_focusPoint = Vector3.Lerp( _focusPoint, FollowedEntity.Position, 50f * RealTime.Delta );
+
+		var trace = Trace.Ray( _focusPoint, _focusPoint + GetViewOffset() )
 			.WorldOnly()
 			.Run();
 
-		Position = Vector3.Lerp( Position, trace.EndPosition, 50f * RealTime.Delta );
+		Position = trace.EndPosition;
 	}
 
 	public virtual Vector3 GetViewOffset()

--- a/code/Player/Cameras/FreeSpectateCamera.cs
+++ b/code/Player/Cameras/FreeSpectateCamera.cs
@@ -42,8 +42,8 @@ public class FreeSpectateCamera : CameraMode, ISpectateCamera
 		_targetRot = Rotation.From( _lookAngles );
 		_targetPos += mv;
 
-		Position = Vector3.Lerp( Position, _targetPos, 10 * RealTime.Delta * (1 - LerpMode) );
-		Rotation = Rotation.Slerp( Rotation, _targetRot, 10 * RealTime.Delta * (1 - LerpMode) );
+		Position = _targetPos;
+		Rotation = _targetRot;
 	}
 
 	public override void BuildInput( InputBuilder input )

--- a/code/Player/Cameras/FreeSpectateCamera.cs
+++ b/code/Player/Cameras/FreeSpectateCamera.cs
@@ -6,13 +6,9 @@ public class FreeSpectateCamera : CameraMode, ISpectateCamera
 {
 	private Angles _lookAngles;
 	private Vector3 _moveInput;
-
+	private float _moveSpeed;
 	private Vector3 _targetPos;
 	private Rotation _targetRot;
-
-	private float _moveSpeed;
-
-	private const float LerpMode = 0;
 
 	public override void Activated()
 	{
@@ -26,13 +22,6 @@ public class FreeSpectateCamera : CameraMode, ISpectateCamera
 		_lookAngles = Rotation.Angles();
 
 		Viewer = Local.Pawn;
-	}
-
-	public override void Deactivated()
-	{
-		base.Deactivated();
-
-		Viewer = null;
 	}
 
 	public override void Update()

--- a/code/Player/Cameras/ThirdPersonSpectateCamera.cs
+++ b/code/Player/Cameras/ThirdPersonSpectateCamera.cs
@@ -6,6 +6,7 @@ public class ThirdPersonSpectateCamera : CameraMode, ISpectateCamera
 {
 	private Vector3 DefaultPosition { get; }
 	private const int CameraDistance = 120;
+
 	private Vector3 _targetPos;
 	private Angles _lookAngles;
 

--- a/code/Player/Cameras/ThirdPersonSpectateCamera.cs
+++ b/code/Player/Cameras/ThirdPersonSpectateCamera.cs
@@ -6,8 +6,6 @@ public class ThirdPersonSpectateCamera : CameraMode, ISpectateCamera
 {
 	private Vector3 DefaultPosition { get; }
 	private const int CameraDistance = 120;
-
-	private Rotation _targetRot;
 	private Vector3 _targetPos;
 	private Angles _lookAngles;
 
@@ -32,8 +30,7 @@ public class ThirdPersonSpectateCamera : CameraMode, ISpectateCamera
 
 	public override void Update()
 	{
-		_targetRot = Rotation.From( _lookAngles );
-		Rotation = _targetRot;
+		Rotation = Rotation.From( _lookAngles );
 
 		_targetPos = Vector3.Lerp( _targetPos, GetSpectatePoint(), 50f * RealTime.Delta );
 

--- a/code/Player/Cameras/ThirdPersonSpectateCamera.cs
+++ b/code/Player/Cameras/ThirdPersonSpectateCamera.cs
@@ -3,10 +3,9 @@ using Sandbox;
 namespace TTT;
 
 public class ThirdPersonSpectateCamera : CameraMode, ISpectateCamera
-{
-	private Vector3 DefaultPosition { get; }
+{	
 	private const int CameraDistance = 120;
-
+	private readonly Vector3 _defaultPosition;
 	private Vector3 _targetPos;
 	private Angles _lookAngles;
 
@@ -24,8 +23,7 @@ public class ThirdPersonSpectateCamera : CameraMode, ISpectateCamera
 	{
 		if ( Local.Pawn is not Player player )
 			return;
-
-		Viewer = Local.Pawn;
+	
 		player.CurrentPlayer = null;
 	}
 
@@ -45,7 +43,7 @@ public class ThirdPersonSpectateCamera : CameraMode, ISpectateCamera
 	private Vector3 GetSpectatePoint()
 	{
 		if ( Local.Pawn is not Player player || !player.IsSpectatingPlayer )
-			return DefaultPosition;
+			return _defaultPosition;
 
 		return player.CurrentPlayer.EyePosition;
 	}

--- a/code/Player/Cameras/ThirdPersonSpectateCamera.cs
+++ b/code/Player/Cameras/ThirdPersonSpectateCamera.cs
@@ -33,15 +33,15 @@ public class ThirdPersonSpectateCamera : CameraMode, ISpectateCamera
 	public override void Update()
 	{
 		_targetRot = Rotation.From( _lookAngles );
-		Rotation = Rotation.Slerp( Rotation, _targetRot, 25f * RealTime.Delta );
+		Rotation = _targetRot;
 
-		_targetPos = GetSpectatePoint() + Rotation.Forward * -CameraDistance;
+		_targetPos = Vector3.Lerp( _targetPos, GetSpectatePoint(), 50f * RealTime.Delta );
 
-		var trace = Trace.Ray( GetSpectatePoint(), _targetPos )
+		var trace = Trace.Ray( _targetPos, _targetPos + Rotation.Forward * -CameraDistance )
 			.WorldOnly()
 			.Run();
 
-		Position = Vector3.Lerp( Position, trace.EndPosition, 50f * RealTime.Delta );
+		Position = trace.EndPosition;
 	}
 
 	private Vector3 GetSpectatePoint()


### PR DESCRIPTION
I removed the mouse smoothing from the spectator cameras caused by LERPing the camera rotation over time.

For the FollowEntityCamera (brief death corpse camera) and the ThirdPersonSpectateCamera, the position relative to the player was LERPed as well. I removed rotational/relative LERPing but kept world-relative LERPing in these cases (you will now rotate instantly around the entity, but movement of your camera caused by the entity will be smoothed by the same amount as before). I also removed positional LERPing from the FreeSpectateCamera.

~~Note that when Facepunch eventually fixes the stuttery netcode/interpolation, we might want to reduce/remove the world-relative LERPing as well. This is because the entity's position would automatically be smoothed out, and since LERPing follow camera movement can cause it to briefly phase through walls when the followed entity moves (the follow cameras currently stick through the wall a little when they are pushed against the wall, but that's a different problem).~~