### PR TITLE
Fix: List shuffle never moves the last item after the first iteration

### DIFF
--- a/code/Util/ListExtensions.cs
+++ b/code/Util/ListExtensions.cs
@@ -16,7 +16,7 @@ public static class ListExtensions
 		while ( n > 1 )
 		{
 			n--;
-			var k = _random.Next( 0, n );
+			var k = _random.Next( 0, n + 1 );
 			(list[n], list[k]) = (list[k], list[n]);
 		}
 	}


### PR DESCRIPTION
The list shuffle method was changed to use System.Random in https://github.com/sbox-TTT/TTT/commit/2b30105c76a830cc7f430ab1b1a64a894eaf9385. System.Random's Next() method does not include the second number in the given range, while Sandbox.Rand's Int() method does. This was not taken into account, so the last item in the list would never be moved after the first iteration.