### PR TITLE
Fix #225: Gun sounds played at weapon instead of player

### DIFF
--- a/code/Items/Base/Carriable.cs
+++ b/code/Items/Base/Carriable.cs
@@ -178,11 +178,10 @@ public abstract partial class Carriable : AnimatedEntity, IEntityHint, IUse
 
 	public override Sound PlaySound( string soundName, string attachment )
 	{
-		if ( Host.IsClient )
-			return Local.Pawn.PlaySound( soundName )
-				.SetVolume( 0.9f );
+		if ( Owner.IsValid() )
+			return Owner.PlaySound( soundName, attachment );
 
-		return Sound.FromEntity( To.Multiple( Client.All.Where( x => x != Prediction.CurrentHost ) ), soundName, this );
+		return base.PlaySound( soundName, attachment );
 	}
 
 	public virtual void SimulateAnimator( PawnAnimator animator )

--- a/code/Items/Base/Carriable.cs
+++ b/code/Items/Base/Carriable.cs
@@ -176,6 +176,15 @@ public abstract partial class Carriable : AnimatedEntity, IEntityHint, IUse
 		TimeSinceDropped = 0;
 	}
 
+	public override Sound PlaySound( string soundName, string attachment )
+	{
+		if ( Host.IsClient )
+			return Local.Pawn.PlaySound( soundName )
+				.SetVolume( 0.9f );
+
+		return Sound.FromEntity( To.Multiple( Client.All.Where( x => x != Prediction.CurrentHost ) ), soundName, this );
+	}
+
 	public virtual void SimulateAnimator( PawnAnimator animator )
 	{
 		animator.SetAnimParameter( "holdtype", (int)Info.HoldType );


### PR DESCRIPTION
Client weapon sounds are played at the weapon world position, instead of the player's eye position or view model position. Thus, the weirdness of shoot sounds can vary wildly depending on whether the player is flicking their mouse, moving, or crouched. If the player shoots while standing still, the sound is louder on the right.

This problem doesn't exist in the Sandbox gamemode because weapon sounds there are played on the player, not the weapon.

I made the game play carriable sounds from the carriable's owner if there is one. ~~and I made it send the sound attached to the weapon to anyone that isn't the currently predicted player (in case Carriable.PlaySound is called from the server). I also made it play at 90% volume for the local player because it sounded far louder than it did for my second client right next to me.~~